### PR TITLE
Add flag to specify additional C++ modules that expose QML types

### DIFF
--- a/pyside6_qml_stubgen/__main__.py
+++ b/pyside6_qml_stubgen/__main__.py
@@ -2,7 +2,7 @@
 Generate QML stub files (.qmltypes) from Python modules (which use PySide6)
 
 Usage:
-    pyside6-qml-stubgen <in-dir>... --out-dir=<out-dir> [--ignore=<path>...] [--metatypes-dir=<dir>] [--qmltyperegistrar-path=<path>] [--force-rebuild] [--file-relative-path=<div>]
+    pyside6-qml-stubgen <in-dir>... --out-dir=<out-dir> [--ignore=<path>...] [--metatypes-dir=<dir>] [--qmltyperegistrar-path=<path>] [--force-rebuild] [--file-relative-path=<div>] [--extra-external-modules=<modules>]
 
 Options:
     --ignore=<path>                     Ignore all Python files that are children of this path
@@ -11,6 +11,7 @@ Options:
     --force-rebuild                     Rebuild the stubs from scratch instead of doing a partial update
     --file-relative-path=<div>          Make all paths in generated type files relative to this path
                                             (useful for if the generated stubs need to be used on different systems)
+    --extra-external-modules=<modules>  Additional modules which should be assumed to contain QML exposed types (comma separated)
 """
 
 import pathlib
@@ -40,6 +41,11 @@ def main() -> None:
             else None
         ),
         force_rebuild=args["--force-rebuild"],
+        extra_external_modules=(
+            {m.strip() for m in args["--extra-external-modules"].split(",")}
+            if args["--extra-external-modules"]
+            else None
+        ),
     )
 
 


### PR DESCRIPTION
pyside6-qml-stubgen cannot find out where a type comes from unless it is registered from Python, so add a way of using import detection instead.