### PR TITLE
Fixes for Qt 6.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,13 +53,14 @@ $ pyside6-qml-stubgen --help
 Generate QML stub files (.qmltypes) from Python modules (which use PySide6)
 
 Usage:
-    pyside6-qml-stubgen <in-dir>... --out-dir=<out-dir> [--ignore=<path>...] [--metatypes-dir=<dir>] [--qmltyperegistrar-path=<path>] [--force-rebuild] [--file-relative-path=<div>]
+    pyside6-qml-stubgen <in-dir>... --out-dir=<out-dir> [--ignore=<path>...] [--metatypes-dir=<dir>] [--qmltyperegistrar-path=<path>] [--force-rebuild] [--file-relative-path=<div>] [--extra-external-modules=<modules>]
 
 Options:
-    --ignore=<path>                     Ignore all Python files that are children of thispath
+    --ignore=<path>                     Ignore all Python files that are children of this path
     --metatypes-dir=<dir>               Directory of the Qt 6 metatype files for core modules (automatically detected if not provided)
     --qmltyperegistrar-path=<path>      Path of the qmltyperegistrar tool (automatically detected if not provided)
     --force-rebuild                     Rebuild the stubs from scratch instead of doing a partial update
     --file-relative-path=<div>          Make all paths in generated type files relative to this path
                                             (useful for if the generated stubs need to be used on different systems)
+    --extra-external-modules=<modules>  Additional modules which should be assumed to contain QML exposed types (comma separated)
 ```


### PR DESCRIPTION
Fixes for things noticed when updating to 6.8:

 - Fix warnings from qmltyperegistrar about violating the ODR
 - Fix types not actually being registered with Qt, leading to properties not being added
 - Update README